### PR TITLE
vm/qemu: Disable VGA on ppc64

### DIFF
--- a/vm/qemu/qemu.go
+++ b/vm/qemu/qemu.go
@@ -119,6 +119,7 @@ var archConfigs = map[string]*archConfig{
 	"linux/ppc64le": {
 		Qemu:      "qemu-system-ppc64",
 		TargetDir: "/",
+		QemuArgs:  "-vga none",
 		CmdLine:   linuxCmdline,
 	},
 	"freebsd/amd64": {


### PR DESCRIPTION
This works around some bugs in the ppc kernel console code

Signed-off-by: Andrew Donnellan <andrew.donnellan@au1.ibm.com>

*******************************************************************************
Before sending a pull request, please review Contribution Guidelines:
https://github.com/google/syzkaller/blob/master/docs/contributing.md
*******************************************************************************
